### PR TITLE
Fix the worker count loop logic

### DIFF
--- a/sse/client.go
+++ b/sse/client.go
@@ -51,7 +51,7 @@ func (p *Client) Start(ctx context.Context, lastEventID int) error {
 	groupErrs.Go(func() error {
 		return p.Streamer.FillStream(ctx, lastEventID, p.EventStream, p.streamErrors)
 	})
-	for i := 1; i < p.WorkersCount; i++ {
+	for i := 0; i < p.WorkersCount; i++ {
 		newCtx := context.WithValue(ctx, CtxWorkerIDKey, i)
 		groupErrs.Go(func() error {
 			return p.Consumer.Run(newCtx, p.EventStream, p.consumerErrors)

--- a/tests/sse/client_test.go
+++ b/tests/sse/client_test.go
@@ -34,5 +34,21 @@ func Test_HttpConnection_request(t *testing.T) {
 		return nil
 	})
 	assert.Error(t, client.Start(context.Background(), 123))
+}
 
+func Test_withOneWorker_shouldProcessRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, err := writer.Write(json.RawMessage(`data: {"ApiVersion":"1.0.0"}`))
+		require.NoError(t, err)
+	}))
+
+	client := sse.NewClient(server.URL)
+	client.WorkersCount = 1
+	var result bool
+	client.RegisterHandler(sse.APIVersionEventType, func(ctx context.Context, event sse.RawEvent) error {
+		result = true
+		return nil
+	})
+	assert.Error(t, client.Start(context.Background(), 0))
+	assert.True(t, result)
 }


### PR DESCRIPTION
## Resolves: Client doesn't work with one worker

### Summary

Fixed the worker count loop logic

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


