### PR TITLE
Fix Result parsing logic

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - release/*
 jobs:
   quality-check:
     runs-on: ubuntu-latest

--- a/tests/types/argument_test.go
+++ b/tests/types/argument_test.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/make-software/casper-go-sdk/types"
+)
+
+func Test_ParseResultArgument_shouldParseOk(t *testing.T) {
+	source := `{"cl_type":{"Result":{"ok":"String","err":"String"}},"bytes":"010a00000068656c6c6f776f726c64","parsed":{"Ok":"helloworld"}}`
+	var arg types.Argument
+	err := json.Unmarshal([]byte(source), &arg)
+	require.NoError(t, err)
+	val, err := arg.Value()
+	require.NoError(t, err)
+	assert.True(t, val.Result.IsSuccess)
+	assert.Equal(t, "helloworld", val.Result.Value().String())
+}

--- a/tests/types/cl_value/cl_type/result_test.go
+++ b/tests/types/cl_value/cl_type/result_test.go
@@ -12,23 +12,32 @@ import (
 )
 
 func Test_ResultBool_ToString(t *testing.T) {
-	assert.Equal(t, "(Result: Bool)", cltype.NewResultType(cltype.Bool).String())
+	assert.Equal(t, "(Result: Ok(String), Err(String)", cltype.NewResultType(cltype.String, cltype.String).String())
 }
 
 func Test_ResultBool_FromJson(t *testing.T) {
-	res, err := cltype.FromRawJson(json.RawMessage(`{"Result": "Bool"}`))
+	res, err := cltype.FromRawJson(json.RawMessage(`{"Result":{"ok":"String","err":"String"}}`))
 	require.NoError(t, err)
-	assert.Equal(t, "(Result: Bool)", res.String())
+	assert.Equal(t, "(Result: Ok(String), Err(String)", res.String())
 }
 
 func Test_ResultBool_ToBytes(t *testing.T) {
-	assert.Equal(t, "1000", hex.EncodeToString(cltype.NewResultType(cltype.Bool).Bytes()))
+	assert.Equal(t, "100a0a", hex.EncodeToString(cltype.NewResultType(cltype.String, cltype.String).Bytes()))
 }
 
 func Test_ResultBool_FromBytes(t *testing.T) {
-	inBytes, err := hex.DecodeString("1000")
+	inBytes, err := hex.DecodeString("100a0a")
 	require.NoError(t, err)
 	res, err := cltype.FromBytes(inBytes)
 	require.NoError(t, err)
-	assert.Equal(t, cltype.NewResultType(cltype.Bool), res)
+	assert.Equal(t, cltype.NewResultType(cltype.String, cltype.String), res)
+}
+
+func Test_ResultFromRawJson_InvalidJsonFormat_ExceptError(t *testing.T) {
+	_, err := cltype.FromRawJson(json.RawMessage(`{"Result": "String"}`))
+	assert.ErrorIs(t, cltype.ErrInvalidResultJsonFormat, err)
+	_, err = cltype.FromRawJson(json.RawMessage(`{"Result":{"err":"String"}}`))
+	assert.ErrorIs(t, cltype.ErrInvalidResultJsonFormat, err)
+	_, err = cltype.FromRawJson(json.RawMessage(`{"Result":{"ok":"String"}}`))
+	assert.ErrorIs(t, cltype.ErrInvalidResultJsonFormat, err)
 }

--- a/tests/types/cl_value/result_test.go
+++ b/tests/types/cl_value/result_test.go
@@ -15,7 +15,7 @@ func Test_NewResultFromBuffer_SuccessU32ToString(t *testing.T) {
 	source := "010a000000"
 	inBytes, err := hex.DecodeString(source)
 	require.NoError(t, err)
-	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32))
+	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32, cltype.String))
 	require.NoError(t, err)
 	assert.Equal(t, "Ok(10)", res.String())
 }
@@ -24,7 +24,7 @@ func Test_NewResultFromBuffer_ErrorU32ToString(t *testing.T) {
 	source := "000a000000"
 	inBytes, err := hex.DecodeString(source)
 	require.NoError(t, err)
-	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32))
+	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32, cltype.UInt32))
 	require.NoError(t, err)
 	assert.Equal(t, "Err(10)", res.String())
 }
@@ -33,7 +33,7 @@ func Test_NewResultFromBuffer_U32ToVal(t *testing.T) {
 	source := "010a000000"
 	inBytes, err := hex.DecodeString(source)
 	require.NoError(t, err)
-	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32))
+	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32, cltype.String))
 	require.NoError(t, err)
 	assert.Equal(t, uint32(10), res.Value().UI32.Value())
 }
@@ -42,7 +42,17 @@ func Test_FromBytesByType_ResultU32ToVal(t *testing.T) {
 	source := "010a000000"
 	inBytes, err := hex.DecodeString(source)
 	require.NoError(t, err)
-	res, err := clvalue.FromBytesByType(inBytes, cltype.NewResultType(cltype.UInt32))
+	res, err := clvalue.FromBytesByType(inBytes, cltype.NewResultType(cltype.UInt32, cltype.String))
 	require.NoError(t, err)
 	assert.Equal(t, uint32(10), res.Result.Value().UI32.Value())
+}
+
+func Test_FromBytesByType_ResultErr(t *testing.T) {
+	source := "00050000005568206f68"
+	inBytes, err := hex.DecodeString(source)
+	require.NoError(t, err)
+	res, err := clvalue.FromBytesByType(inBytes, cltype.NewResultType(cltype.UInt32, cltype.String))
+	require.NoError(t, err)
+	assert.False(t, res.Result.IsSuccess)
+	assert.Equal(t, "Uh oh", res.Result.Value().String())
 }

--- a/types/clvalue/cltype/result.go
+++ b/types/clvalue/cltype/result.go
@@ -3,19 +3,23 @@ package cltype
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
+var ErrInvalidResultJsonFormat = errors.New("invalid json format for Result type")
+
 type Result struct {
-	Inner CLType
+	InnerOk  CLType
+	InnerErr CLType
 }
 
 func (t *Result) Bytes() []byte {
-	return append([]byte{t.GetTypeID()}, (t.Inner).Bytes()...)
+	return append([]byte{t.GetTypeID()}, append((t.InnerOk).Bytes(), t.InnerErr.Bytes()...)...)
 }
 
 func (t *Result) String() string {
-	return fmt.Sprintf("(%s: %s)", t.Name(), t.Inner.Name())
+	return fmt.Sprintf("(%s: Ok(%s), Err(%s)", t.Name(), t.InnerOk.Name(), t.InnerErr.Name())
 }
 
 func (t *Result) GetTypeID() TypeID {
@@ -27,25 +31,45 @@ func (t *Result) Name() TypeName {
 }
 
 func (t *Result) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]CLType{t.Name(): t.Inner})
+	return json.Marshal(map[string]map[string]CLType{t.Name(): {"ok": t.InnerOk, "err": t.InnerErr}})
 }
 
-func NewResultType(inner CLType) *Result {
-	return &Result{Inner: inner}
+func NewResultType(innerOk CLType, innerErr CLType) *Result {
+	return &Result{InnerOk: innerOk, InnerErr: innerErr}
 }
 
 func NewResultFromJson(source interface{}) (*Result, error) {
-	inner, err := fromInterface(source)
+	data, ok := source.(map[string]interface{})
+	if !ok {
+		return nil, ErrInvalidResultJsonFormat
+	}
+	okData, found := data["ok"]
+	if !found {
+		return nil, ErrInvalidResultJsonFormat
+	}
+	innerOk, err := fromInterface(okData)
 	if err != nil {
 		return nil, err
 	}
-	return NewResultType(inner), nil
+	errData, found := data["err"]
+	if !found {
+		return nil, ErrInvalidResultJsonFormat
+	}
+	innerErr, err := fromInterface(errData)
+	if err != nil {
+		return nil, err
+	}
+	return NewResultType(innerOk, innerErr), nil
 }
 
 func NewResultFromBuffer(buf *bytes.Buffer) (*Result, error) {
-	inner, err := FromBuffer(buf)
+	innerOk, err := FromBuffer(buf)
 	if err != nil {
 		return nil, err
 	}
-	return NewResultType(inner), nil
+	innerErr, err := FromBuffer(buf)
+	if err != nil {
+		return nil, err
+	}
+	return NewResultType(innerOk, innerErr), nil
 }

--- a/types/clvalue/result.go
+++ b/types/clvalue/result.go
@@ -28,8 +28,8 @@ func (v *Result) Value() CLValue {
 	return v.Inner
 }
 
-func NewCLResult(innerType cltype.CLType, value CLValue, isSuccess bool) CLValue {
-	resultType := cltype.NewResultType(innerType)
+func NewCLResult(innerOk, innerErr cltype.CLType, value CLValue, isSuccess bool) CLValue {
+	resultType := cltype.NewResultType(innerOk, innerErr)
 	return CLValue{
 		Type: resultType,
 		Result: &Result{
@@ -52,11 +52,19 @@ func NewResultFromBuffer(buf *bytes.Buffer, clType *cltype.Result) (*Result, err
 		return nil, err
 	}
 	val.IsSuccess = isSuccess == 1
-	inner, err := FromBufferByType(buf, clType.Inner)
-	if err != nil {
-		return nil, err
+	if val.IsSuccess {
+		inner, err := FromBufferByType(buf, clType.InnerOk)
+		if err != nil {
+			return nil, err
+		}
+		val.Inner = inner
+	} else {
+		inner, err := FromBufferByType(buf, clType.InnerErr)
+		if err != nil {
+			return nil, err
+		}
+		val.Inner = inner
 	}
-	val.Inner = inner
 
 	return &val, nil
 }


### PR DESCRIPTION
## Fixed CLResult parsing logic

* Resolves: # The GetContractItemLatest method failed on reading the hash (testnet) d8afda72c273c06427c03b6fec5fb87bd3033faaa72270902775cff9aa843350 and path "name".

### Summary
 Parsing logic for CLType "Result" was implemented in wrong way.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


