### PR TITLE
Fix contract version type

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - release/*
 jobs:
   quality-check:
     runs-on: ubuntu-latest

--- a/tests/data/deploy/deploy_with_stored_contract_by_hash_with_version.json
+++ b/tests/data/deploy/deploy_with_stored_contract_by_hash_with_version.json
@@ -1,0 +1,50 @@
+{
+  "hash": "e07b9e01ba4e93a632e07be48541aa8f3827e43c07dbf647c6c878866a45b7b7",
+  "header": {
+    "account": "01d330e3e706815cfa30df46f9183fd6984597f6dd8e026365fd71a8702bc3fb94",
+    "timestamp": "2021-09-09T04:38:16.063Z",
+    "ttl": "30m",
+    "gas_price": 1,
+    "body_hash": "3b88d9461f8f16e6975db372fffaa4198bbd5f818fb95c262eecdf3d22b77918",
+    "dependencies": [],
+    "chain_name": "casper-test"
+  },
+  "payment": {
+    "ModuleBytes": {
+      "module_bytes": "",
+      "args": [
+        [
+          "amount",
+          {
+            "cl_type": "U512",
+            "bytes": "04005ed0b2",
+            "parsed": "3000000000"
+          }
+        ]
+      ]
+    }
+  },
+  "session": {
+    "StoredVersionedContractByHash": {
+      "hash": "8ff7a1c49017400013dcf78305343fa07c31b04292b7928845ed59764e1ee512",
+      "version": 2,
+      "entry_point": "get_message",
+      "args": [
+        [
+          "amount",
+          {
+            "cl_type": "U256",
+            "bytes": "0400f90295",
+            "parsed": "2500000000"
+          }
+        ]
+      ]
+    }
+  },
+  "approvals": [
+    {
+      "signer": "01d330e3e706815cfa30df46f9183fd6984597f6dd8e026365fd71a8702bc3fb94",
+      "signature": "01b2fccab6e34b2c584e21fd2e7da22c8c048ff4aea3c818728c399a4ec625973d0f8b8f2a2202a0899b6362d3f6a4e26d80976523c7587095bee1b1f260a93e07"
+    }
+  ]
+}

--- a/tests/types/deploy_executable_item_test.go
+++ b/tests/types/deploy_executable_item_test.go
@@ -33,7 +33,7 @@ func Test_ExecutableItem_MarshalUnmarshal_ShouldBeSameResult(t *testing.T) {
 		},
 		{
 			"item with stored versioned contract by name",
-			`{"StoredVersionedContractByName": {"name": "lWJWKdZUEudSakJzw1tn","version": "Some(1632552656)","entry_point": "S1cXRT3E1jyFlWBAIVQ8","args": [["testName", "testVal"]]}}`,
+			`{"StoredVersionedContractByName": {"name": "lWJWKdZUEudSakJzw1tn","version": 1632552656, "entry_point": "S1cXRT3E1jyFlWBAIVQ8","args": [["testName", "testVal"]]}}`,
 		},
 		{
 			"item with stored transfer",

--- a/tests/types/deploy_test.go
+++ b/tests/types/deploy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/make-software/casper-go-sdk/types"
 )
@@ -23,18 +24,22 @@ func Test_Deploy_MarshalUnmarshal_ShouldBeSameResult(t *testing.T) {
 			"deploy with StoredContractByHash",
 			"../data/deploy/deploy_with_stored_contract_by_hash.json",
 		},
+		{
+			"deploy with StoredContractByHash with version",
+			"../data/deploy/deploy_with_stored_contract_by_hash_with_version.json",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			data, err := os.ReadFile(test.fixturePath)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			var deploy types.Deploy
 			err = json.Unmarshal(data, &deploy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			result, err := json.Marshal(deploy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.JSONEq(t, string(data), string(result), test.name)
 		})
 	}

--- a/types/executable_deploy_item.go
+++ b/types/executable_deploy_item.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"math/big"
+	"strconv"
 
 	"github.com/make-software/casper-go-sdk/types/clvalue"
 	"github.com/make-software/casper-go-sdk/types/key"
@@ -130,15 +132,20 @@ type StoredVersionedContractByHash struct {
 	// Hash of the contract.
 	Hash key.ContractHash `json:"hash"`
 	// Entry point or method of the contract to call.
-	EntryPoint string  `json:"entry_point"`
-	Version    *string `json:"version,omitempty"`
-	Args       *Args   `json:"args"`
+	EntryPoint string       `json:"entry_point"`
+	Version    *json.Number `json:"version,omitempty"`
+	Args       *Args        `json:"args"`
 }
 
 func (m StoredVersionedContractByHash) Bytes() ([]byte, error) {
 	option := clvalue.Option{}
-	if m.Version != nil || *m.Version != "" {
-		option.Inner = clvalue.NewCLString(*m.Version)
+	if m.Version != nil || m.Version.String() != "" {
+		verVal, err := strconv.ParseUint(m.Version.String(), 10, 32)
+		if err != nil {
+			return nil, err
+		}
+
+		option.Inner = clvalue.NewCLUInt32(uint32(verVal))
 	}
 	argBytes, err := m.Args.Bytes()
 	if err != nil {
@@ -157,15 +164,20 @@ type StoredVersionedContractByName struct {
 	// Name of a named key in the caller account that stores the contract package hash.
 	Name string `json:"name"`
 	// Entry point or method of the contract to call.
-	EntryPoint string  `json:"entry_point"`
-	Version    *string `json:"version,omitempty"`
-	Args       *Args   `json:"args"`
+	EntryPoint string       `json:"entry_point"`
+	Version    *json.Number `json:"version,omitempty"`
+	Args       *Args        `json:"args"`
 }
 
 func (m StoredVersionedContractByName) Bytes() ([]byte, error) {
 	option := clvalue.Option{}
 	if m.Version != nil || *m.Version != "" {
-		option.Inner = clvalue.NewCLString(*m.Version)
+		verVal, err := strconv.ParseUint(m.Version.String(), 10, 32)
+		if err != nil {
+			return nil, err
+		}
+
+		option.Inner = clvalue.NewCLUInt32(uint32(verVal))
 	}
 	argBytes, err := m.Args.Bytes()
 	if err != nil {


### PR DESCRIPTION
## Fix contract version type

* Resolves: # We have error on unmarshaling deploy e07b9e01ba4e93a632e07be48541aa8f3827e43c07dbf647c6c878866a45b7b7 (testnet) on GetDeploy method.

### Summary

Fixed the data type for the Version field in StoredVersionedContractByHash struct.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


