### PR TITLE
Fix 1day TTL for deploy header

### DIFF
--- a/tests/data/deploy/deploy_header_ttl_1day.json
+++ b/tests/data/deploy/deploy_header_ttl_1day.json
@@ -1,0 +1,9 @@
+{
+  "account": "01226a34b8cbcc24b8a3b758d710010dff63bb6f3b278222f33c294c8e1d6a9e25",
+  "timestamp": "2021-05-11T12:10:58.754Z",
+  "ttl": "1day",
+  "gas_price": 1,
+  "body_hash": "efcbe01ef3a2d9825d99b5a3c5c3dcc574a7c60c5152de39e03e3aeb29aa4400",
+  "dependencies": [],
+  "chain_name": "casper-test"
+}

--- a/tests/types/deploy_header_test.go
+++ b/tests/types/deploy_header_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/make-software/casper-go-sdk/types"
 )
@@ -18,19 +19,22 @@ func Test_DeployHeader_MarshalUnmarshal_ShouldBeSameResult(t *testing.T) {
 		{
 			"deploy with StoredContractByName",
 			"../data/deploy/deploy_header_with_deps.json",
+		}, {
+			"deploy with StoredContractByName",
+			"../data/deploy/deploy_header_ttl_1day.json",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			data, err := os.ReadFile(test.fixturePath)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			var deploy types.DeployHeader
 			err = json.Unmarshal(data, &deploy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			result, err := json.Marshal(deploy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.JSONEq(t, string(data), string(result), test.name)
 		})
 	}

--- a/tests/types/deploy_ttl_test.go
+++ b/tests/types/deploy_ttl_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func Test_DurationUnmarshal_withSpace_shouldBeParsed(t *testing.T) {
-	value := `"1h 30m"`
+	value := `"2h 46m 40s"`
 	var result types.Duration
 	err := json.Unmarshal([]byte(value), &result)
 	require.NoError(t, err)
 	data, err := result.MarshalJSON()
 	require.NoError(t, err)
-	assert.Equal(t, `"1h30m"`, string(data))
+	assert.Equal(t, `"2h46m40s"`, string(data))
 }

--- a/tests/types/deploy_ttl_test.go
+++ b/tests/types/deploy_ttl_test.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/make-software/casper-go-sdk/types"
+)
+
+func Test_DurationUnmarshal_withSpace_shouldBeParsed(t *testing.T) {
+	value := `"1h 30m"`
+	var result types.Duration
+	err := json.Unmarshal([]byte(value), &result)
+	require.NoError(t, err)
+	data, err := result.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, `"1h30m"`, string(data))
+}

--- a/types/time.go
+++ b/types/time.go
@@ -54,7 +54,7 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &dataString); err != nil {
 		return err
 	}
-
+	dataString = strings.ReplaceAll(dataString, " ", "")
 	if dataString == "1day" {
 		dataString = "24h"
 	}

--- a/types/time.go
+++ b/types/time.go
@@ -36,6 +36,9 @@ type Duration time.Duration
 
 func (d Duration) MarshalJSON() ([]byte, error) {
 	s := time.Duration(d).String()
+	if s == "24h0m0s" {
+		s = "1day"
+	}
 	if strings.HasSuffix(s, "h0m0s") {
 		s = strings.TrimSuffix(s, "0m0s")
 	}
@@ -52,6 +55,9 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	if dataString == "1day" {
+		dataString = "24h"
+	}
 	duration, err := time.ParseDuration(dataString)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Fix 1day TTL for deploy header

* Resolves: #The problem is that types.Duration type is not supported for parsing ttl:"1day" format.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


