### PR TITLE
Release/v1.1.3

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - release/*
 jobs:
   quality-check:
     runs-on: ubuntu-latest

--- a/tests/data/deploy/deploy_header_ttl_1day.json
+++ b/tests/data/deploy/deploy_header_ttl_1day.json
@@ -1,0 +1,9 @@
+{
+  "account": "01226a34b8cbcc24b8a3b758d710010dff63bb6f3b278222f33c294c8e1d6a9e25",
+  "timestamp": "2021-05-11T12:10:58.754Z",
+  "ttl": "1day",
+  "gas_price": 1,
+  "body_hash": "efcbe01ef3a2d9825d99b5a3c5c3dcc574a7c60c5152de39e03e3aeb29aa4400",
+  "dependencies": [],
+  "chain_name": "casper-test"
+}

--- a/tests/data/deploy/deploy_with_stored_contract_by_hash_with_version.json
+++ b/tests/data/deploy/deploy_with_stored_contract_by_hash_with_version.json
@@ -1,0 +1,50 @@
+{
+  "hash": "e07b9e01ba4e93a632e07be48541aa8f3827e43c07dbf647c6c878866a45b7b7",
+  "header": {
+    "account": "01d330e3e706815cfa30df46f9183fd6984597f6dd8e026365fd71a8702bc3fb94",
+    "timestamp": "2021-09-09T04:38:16.063Z",
+    "ttl": "30m",
+    "gas_price": 1,
+    "body_hash": "3b88d9461f8f16e6975db372fffaa4198bbd5f818fb95c262eecdf3d22b77918",
+    "dependencies": [],
+    "chain_name": "casper-test"
+  },
+  "payment": {
+    "ModuleBytes": {
+      "module_bytes": "",
+      "args": [
+        [
+          "amount",
+          {
+            "cl_type": "U512",
+            "bytes": "04005ed0b2",
+            "parsed": "3000000000"
+          }
+        ]
+      ]
+    }
+  },
+  "session": {
+    "StoredVersionedContractByHash": {
+      "hash": "8ff7a1c49017400013dcf78305343fa07c31b04292b7928845ed59764e1ee512",
+      "version": 2,
+      "entry_point": "get_message",
+      "args": [
+        [
+          "amount",
+          {
+            "cl_type": "U256",
+            "bytes": "0400f90295",
+            "parsed": "2500000000"
+          }
+        ]
+      ]
+    }
+  },
+  "approvals": [
+    {
+      "signer": "01d330e3e706815cfa30df46f9183fd6984597f6dd8e026365fd71a8702bc3fb94",
+      "signature": "01b2fccab6e34b2c584e21fd2e7da22c8c048ff4aea3c818728c399a4ec625973d0f8b8f2a2202a0899b6362d3f6a4e26d80976523c7587095bee1b1f260a93e07"
+    }
+  ]
+}

--- a/tests/types/argument_test.go
+++ b/tests/types/argument_test.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/make-software/casper-go-sdk/types"
+)
+
+func Test_ParseResultArgument_shouldParseOk(t *testing.T) {
+	source := `{"cl_type":{"Result":{"ok":"String","err":"String"}},"bytes":"010a00000068656c6c6f776f726c64","parsed":{"Ok":"helloworld"}}`
+	var arg types.Argument
+	err := json.Unmarshal([]byte(source), &arg)
+	require.NoError(t, err)
+	val, err := arg.Value()
+	require.NoError(t, err)
+	assert.True(t, val.Result.IsSuccess)
+	assert.Equal(t, "helloworld", val.Result.Value().String())
+}

--- a/tests/types/cl_value/cl_type/result_test.go
+++ b/tests/types/cl_value/cl_type/result_test.go
@@ -12,23 +12,32 @@ import (
 )
 
 func Test_ResultBool_ToString(t *testing.T) {
-	assert.Equal(t, "(Result: Bool)", cltype.NewResultType(cltype.Bool).String())
+	assert.Equal(t, "(Result: Ok(String), Err(String)", cltype.NewResultType(cltype.String, cltype.String).String())
 }
 
 func Test_ResultBool_FromJson(t *testing.T) {
-	res, err := cltype.FromRawJson(json.RawMessage(`{"Result": "Bool"}`))
+	res, err := cltype.FromRawJson(json.RawMessage(`{"Result":{"ok":"String","err":"String"}}`))
 	require.NoError(t, err)
-	assert.Equal(t, "(Result: Bool)", res.String())
+	assert.Equal(t, "(Result: Ok(String), Err(String)", res.String())
 }
 
 func Test_ResultBool_ToBytes(t *testing.T) {
-	assert.Equal(t, "1000", hex.EncodeToString(cltype.NewResultType(cltype.Bool).Bytes()))
+	assert.Equal(t, "100a0a", hex.EncodeToString(cltype.NewResultType(cltype.String, cltype.String).Bytes()))
 }
 
 func Test_ResultBool_FromBytes(t *testing.T) {
-	inBytes, err := hex.DecodeString("1000")
+	inBytes, err := hex.DecodeString("100a0a")
 	require.NoError(t, err)
 	res, err := cltype.FromBytes(inBytes)
 	require.NoError(t, err)
-	assert.Equal(t, cltype.NewResultType(cltype.Bool), res)
+	assert.Equal(t, cltype.NewResultType(cltype.String, cltype.String), res)
+}
+
+func Test_ResultFromRawJson_InvalidJsonFormat_ExceptError(t *testing.T) {
+	_, err := cltype.FromRawJson(json.RawMessage(`{"Result": "String"}`))
+	assert.ErrorIs(t, cltype.ErrInvalidResultJsonFormat, err)
+	_, err = cltype.FromRawJson(json.RawMessage(`{"Result":{"err":"String"}}`))
+	assert.ErrorIs(t, cltype.ErrInvalidResultJsonFormat, err)
+	_, err = cltype.FromRawJson(json.RawMessage(`{"Result":{"ok":"String"}}`))
+	assert.ErrorIs(t, cltype.ErrInvalidResultJsonFormat, err)
 }

--- a/tests/types/cl_value/int32_test.go
+++ b/tests/types/cl_value/int32_test.go
@@ -1,22 +1,33 @@
 package cl_value
 
 import (
+	"encoding/hex"
 	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/make-software/casper-go-sdk/types/clvalue"
 )
 
 func Test_NewInt32FromBuffer_maxValue(t *testing.T) {
 	maxInBytes := clvalue.NewCLInt32(math.MaxInt32).Bytes()
-	res := clvalue.NewInt32FromBytes(maxInBytes)
+	res, err := clvalue.NewInt32FromBytes(maxInBytes)
+	require.NoError(t, err)
 	assert.Equal(t, int32(math.MaxInt32), res.Value())
 }
 
 func Test_NewInt32FromBuffer_negative(t *testing.T) {
 	maxInBytes := clvalue.NewCLUInt32(math.MaxUint32).Bytes()
-	res := clvalue.NewInt32FromBytes(maxInBytes)
+	res, err := clvalue.NewInt32FromBytes(maxInBytes)
+	require.NoError(t, err)
 	assert.Equal(t, int32(-1), res.Value())
+}
+
+func Test_NewUInt32IncompleteFormat_ShouldRaiseError(t *testing.T) {
+	src, err := hex.DecodeString("0700")
+	require.NoError(t, err)
+	_, err = clvalue.NewInt32FromBytes(src)
+	assert.Error(t, err)
 }

--- a/tests/types/cl_value/int64_test.go
+++ b/tests/types/cl_value/int64_test.go
@@ -1,6 +1,7 @@
 package cl_value
 
 import (
+	"encoding/hex"
 	"math"
 	"testing"
 
@@ -17,8 +18,16 @@ func Test_Int64_ToString(t *testing.T) {
 
 func Test_NewInt64FromBuffer_maxValue(t *testing.T) {
 	maxInBytes := clvalue.NewCLInt64(math.MaxInt64).Bytes()
-	res := clvalue.NewInt64FromBytes(maxInBytes)
+	res, err := clvalue.NewInt64FromBytes(maxInBytes)
+	require.NoError(t, err)
 	assert.Equal(t, int64(math.MaxInt64), res.Value())
+}
+
+func Test_NewInt64FromBufferIncompleteFormat_ShouldRaiseError(t *testing.T) {
+	src, err := hex.DecodeString("0700")
+	require.NoError(t, err)
+	_, err = clvalue.NewInt64FromBytes(src)
+	assert.Error(t, err)
 }
 
 func Test_FromBytesByType_Int64(t *testing.T) {

--- a/tests/types/cl_value/int64_test.go
+++ b/tests/types/cl_value/int64_test.go
@@ -24,7 +24,7 @@ func Test_NewInt64FromBuffer_maxValue(t *testing.T) {
 }
 
 func Test_NewInt64FromBufferIncompleteFormat_ShouldRaiseError(t *testing.T) {
-	src, err := hex.DecodeString("0700")
+	src, err := hex.DecodeString("07000000")
 	require.NoError(t, err)
 	_, err = clvalue.NewInt64FromBytes(src)
 	assert.Error(t, err)

--- a/tests/types/cl_value/list_test.go
+++ b/tests/types/cl_value/list_test.go
@@ -20,6 +20,14 @@ func Test_NewListFromBuffer_EmptyToString(t *testing.T) {
 	assert.Equal(t, "[]", res.String())
 }
 
+func Test_NewListFromBuffer_IncompleteFormat_ShouldRaiseError(t *testing.T) {
+	source := "000000"
+	inBytes, err := hex.DecodeString(source)
+	require.NoError(t, err)
+	_, err = clvalue.NewListFromBytes(inBytes, cltype.NewList(cltype.Bool))
+	assert.Error(t, err)
+}
+
 func Test_NewListFromBuffer_EmptyToVal(t *testing.T) {
 	source := "00000000"
 	inBytes, err := hex.DecodeString(source)

--- a/tests/types/cl_value/map_test.go
+++ b/tests/types/cl_value/map_test.go
@@ -1,6 +1,8 @@
 package cl_value
 
 import (
+	"bytes"
+	"encoding/hex"
 	"math/big"
 	"testing"
 
@@ -62,4 +64,12 @@ func Test_Map_ToData(t *testing.T) {
 		"uref-7b12008bb757ee32caefb3f7a1f77d9f659ee7a4e21ad4950c4e0294000492eb-007",
 		result[1].Inner1.Key.URef.String(),
 	)
+}
+
+func Test_NewMapFromBuffer_IncompleteFormat_ShouldRaiseError(t *testing.T) {
+	source := "0000"
+	inBytes, err := hex.DecodeString(source)
+	require.NoError(t, err)
+	_, err = clvalue.NewMapFromBuffer(bytes.NewBuffer(inBytes), cltype.NewMap(cltype.String, cltype.String))
+	assert.Error(t, err)
 }

--- a/tests/types/cl_value/result_test.go
+++ b/tests/types/cl_value/result_test.go
@@ -15,7 +15,7 @@ func Test_NewResultFromBuffer_SuccessU32ToString(t *testing.T) {
 	source := "010a000000"
 	inBytes, err := hex.DecodeString(source)
 	require.NoError(t, err)
-	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32))
+	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32, cltype.String))
 	require.NoError(t, err)
 	assert.Equal(t, "Ok(10)", res.String())
 }
@@ -24,7 +24,7 @@ func Test_NewResultFromBuffer_ErrorU32ToString(t *testing.T) {
 	source := "000a000000"
 	inBytes, err := hex.DecodeString(source)
 	require.NoError(t, err)
-	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32))
+	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32, cltype.UInt32))
 	require.NoError(t, err)
 	assert.Equal(t, "Err(10)", res.String())
 }
@@ -33,7 +33,7 @@ func Test_NewResultFromBuffer_U32ToVal(t *testing.T) {
 	source := "010a000000"
 	inBytes, err := hex.DecodeString(source)
 	require.NoError(t, err)
-	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32))
+	res, err := clvalue.NewResultFromBytes(inBytes, cltype.NewResultType(cltype.UInt32, cltype.String))
 	require.NoError(t, err)
 	assert.Equal(t, uint32(10), res.Value().UI32.Value())
 }
@@ -42,7 +42,17 @@ func Test_FromBytesByType_ResultU32ToVal(t *testing.T) {
 	source := "010a000000"
 	inBytes, err := hex.DecodeString(source)
 	require.NoError(t, err)
-	res, err := clvalue.FromBytesByType(inBytes, cltype.NewResultType(cltype.UInt32))
+	res, err := clvalue.FromBytesByType(inBytes, cltype.NewResultType(cltype.UInt32, cltype.String))
 	require.NoError(t, err)
 	assert.Equal(t, uint32(10), res.Result.Value().UI32.Value())
+}
+
+func Test_FromBytesByType_ResultErr(t *testing.T) {
+	source := "00050000005568206f68"
+	inBytes, err := hex.DecodeString(source)
+	require.NoError(t, err)
+	res, err := clvalue.FromBytesByType(inBytes, cltype.NewResultType(cltype.UInt32, cltype.String))
+	require.NoError(t, err)
+	assert.False(t, res.Result.IsSuccess)
+	assert.Equal(t, "Uh oh", res.Result.Value().String())
 }

--- a/tests/types/cl_value/string_test.go
+++ b/tests/types/cl_value/string_test.go
@@ -13,8 +13,16 @@ import (
 func Test_String_Decode_Example(t *testing.T) {
 	src, err := hex.DecodeString("070000004142432d444546")
 	require.NoError(t, err)
-	result := clvalue.NewStringFromBytes(src)
+	result, err := clvalue.NewStringFromBytes(src)
+	require.NoError(t, err)
 	assert.Equal(t, "ABC-DEF", result.String())
+}
+
+func Test_StringIncompleteFormat_ShouldBeError(t *testing.T) {
+	src, err := hex.DecodeString("0700")
+	require.NoError(t, err)
+	_, err = clvalue.NewStringFromBytes(src)
+	assert.Error(t, err)
 }
 
 func Test_String_Encode_Example(t *testing.T) {

--- a/tests/types/cl_value/uint64_test.go
+++ b/tests/types/cl_value/uint64_test.go
@@ -24,7 +24,7 @@ func Test_NewUInt64FromBuffer_maxValue(t *testing.T) {
 }
 
 func Test_NewUInt64IncompleteFormat_ShouldRaiseError(t *testing.T) {
-	src, err := hex.DecodeString("0700")
+	src, err := hex.DecodeString("07000000")
 	require.NoError(t, err)
 	_, err = clvalue.NewUint64FromBytes(src)
 	assert.Error(t, err)

--- a/tests/types/cl_value/uint64_test.go
+++ b/tests/types/cl_value/uint64_test.go
@@ -18,8 +18,16 @@ func Test_UInt64_ToString(t *testing.T) {
 
 func Test_NewUInt64FromBuffer_maxValue(t *testing.T) {
 	maxInBytes := clvalue.NewCLUInt64(math.MaxUint64).Bytes()
-	res := clvalue.NewUint64FromBytes(maxInBytes)
+	res, err := clvalue.NewUint64FromBytes(maxInBytes)
+	require.NoError(t, err)
 	assert.Equal(t, uint64(math.MaxUint64), res.Value())
+}
+
+func Test_NewUInt64IncompleteFormat_ShouldRaiseError(t *testing.T) {
+	src, err := hex.DecodeString("0700")
+	require.NoError(t, err)
+	_, err = clvalue.NewUint64FromBytes(src)
+	assert.Error(t, err)
 }
 
 func Test_FromBytesByType_UInt64(t *testing.T) {

--- a/tests/types/deploy_executable_item_test.go
+++ b/tests/types/deploy_executable_item_test.go
@@ -33,7 +33,7 @@ func Test_ExecutableItem_MarshalUnmarshal_ShouldBeSameResult(t *testing.T) {
 		},
 		{
 			"item with stored versioned contract by name",
-			`{"StoredVersionedContractByName": {"name": "lWJWKdZUEudSakJzw1tn","version": "Some(1632552656)","entry_point": "S1cXRT3E1jyFlWBAIVQ8","args": [["testName", "testVal"]]}}`,
+			`{"StoredVersionedContractByName": {"name": "lWJWKdZUEudSakJzw1tn","version": 1632552656, "entry_point": "S1cXRT3E1jyFlWBAIVQ8","args": [["testName", "testVal"]]}}`,
 		},
 		{
 			"item with stored transfer",

--- a/tests/types/deploy_header_test.go
+++ b/tests/types/deploy_header_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/make-software/casper-go-sdk/types"
 )
@@ -18,19 +19,22 @@ func Test_DeployHeader_MarshalUnmarshal_ShouldBeSameResult(t *testing.T) {
 		{
 			"deploy with StoredContractByName",
 			"../data/deploy/deploy_header_with_deps.json",
+		}, {
+			"deploy with StoredContractByName",
+			"../data/deploy/deploy_header_ttl_1day.json",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			data, err := os.ReadFile(test.fixturePath)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			var deploy types.DeployHeader
 			err = json.Unmarshal(data, &deploy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			result, err := json.Marshal(deploy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.JSONEq(t, string(data), string(result), test.name)
 		})
 	}

--- a/tests/types/deploy_test.go
+++ b/tests/types/deploy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/make-software/casper-go-sdk/types"
 )
@@ -23,18 +24,22 @@ func Test_Deploy_MarshalUnmarshal_ShouldBeSameResult(t *testing.T) {
 			"deploy with StoredContractByHash",
 			"../data/deploy/deploy_with_stored_contract_by_hash.json",
 		},
+		{
+			"deploy with StoredContractByHash with version",
+			"../data/deploy/deploy_with_stored_contract_by_hash_with_version.json",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			data, err := os.ReadFile(test.fixturePath)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			var deploy types.Deploy
 			err = json.Unmarshal(data, &deploy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			result, err := json.Marshal(deploy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.JSONEq(t, string(data), string(result), test.name)
 		})
 	}

--- a/tests/types/deploy_ttl_test.go
+++ b/tests/types/deploy_ttl_test.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/make-software/casper-go-sdk/types"
+)
+
+func Test_DurationUnmarshal_withSpace_shouldBeParsed(t *testing.T) {
+	value := `"2h 46m 40s"`
+	var result types.Duration
+	err := json.Unmarshal([]byte(value), &result)
+	require.NoError(t, err)
+	data, err := result.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, `"2h46m40s"`, string(data))
+}

--- a/types/clvalue/cltype/result.go
+++ b/types/clvalue/cltype/result.go
@@ -3,19 +3,23 @@ package cltype
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
+var ErrInvalidResultJsonFormat = errors.New("invalid json format for Result type")
+
 type Result struct {
-	Inner CLType
+	InnerOk  CLType
+	InnerErr CLType
 }
 
 func (t *Result) Bytes() []byte {
-	return append([]byte{t.GetTypeID()}, (t.Inner).Bytes()...)
+	return append([]byte{t.GetTypeID()}, append((t.InnerOk).Bytes(), t.InnerErr.Bytes()...)...)
 }
 
 func (t *Result) String() string {
-	return fmt.Sprintf("(%s: %s)", t.Name(), t.Inner.Name())
+	return fmt.Sprintf("(%s: Ok(%s), Err(%s)", t.Name(), t.InnerOk.Name(), t.InnerErr.Name())
 }
 
 func (t *Result) GetTypeID() TypeID {
@@ -27,25 +31,45 @@ func (t *Result) Name() TypeName {
 }
 
 func (t *Result) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]CLType{t.Name(): t.Inner})
+	return json.Marshal(map[string]map[string]CLType{t.Name(): {"ok": t.InnerOk, "err": t.InnerErr}})
 }
 
-func NewResultType(inner CLType) *Result {
-	return &Result{Inner: inner}
+func NewResultType(innerOk CLType, innerErr CLType) *Result {
+	return &Result{InnerOk: innerOk, InnerErr: innerErr}
 }
 
 func NewResultFromJson(source interface{}) (*Result, error) {
-	inner, err := fromInterface(source)
+	data, ok := source.(map[string]interface{})
+	if !ok {
+		return nil, ErrInvalidResultJsonFormat
+	}
+	okData, found := data["ok"]
+	if !found {
+		return nil, ErrInvalidResultJsonFormat
+	}
+	innerOk, err := fromInterface(okData)
 	if err != nil {
 		return nil, err
 	}
-	return NewResultType(inner), nil
+	errData, found := data["err"]
+	if !found {
+		return nil, ErrInvalidResultJsonFormat
+	}
+	innerErr, err := fromInterface(errData)
+	if err != nil {
+		return nil, err
+	}
+	return NewResultType(innerOk, innerErr), nil
 }
 
 func NewResultFromBuffer(buf *bytes.Buffer) (*Result, error) {
-	inner, err := FromBuffer(buf)
+	innerOk, err := FromBuffer(buf)
 	if err != nil {
 		return nil, err
 	}
-	return NewResultType(inner), nil
+	innerErr, err := FromBuffer(buf)
+	if err != nil {
+		return nil, err
+	}
+	return NewResultType(innerOk, innerErr), nil
 }

--- a/types/clvalue/int32.go
+++ b/types/clvalue/int32.go
@@ -3,6 +3,7 @@ package clvalue
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/make-software/casper-go-sdk/types/clvalue/cltype"
@@ -32,13 +33,16 @@ func NewCLInt32(val int32) CLValue {
 	return res
 }
 
-func NewInt32FromBytes(source []byte) *Int32 {
+func NewInt32FromBytes(source []byte) (*Int32, error) {
 	buf := bytes.NewBuffer(source)
 	return NewInt32FromBuffer(buf)
 }
 
-func NewInt32FromBuffer(buffer *bytes.Buffer) *Int32 {
+func NewInt32FromBuffer(buffer *bytes.Buffer) (*Int32, error) {
+	if buffer.Len() < cltype.Int32ByteSize {
+		return nil, errors.New("buffer size is too small")
+	}
 	buf := buffer.Next(cltype.Int32ByteSize)
 	val := Int32(int32(binary.LittleEndian.Uint32(buf)))
-	return &val
+	return &val, nil
 }

--- a/types/clvalue/int64.go
+++ b/types/clvalue/int64.go
@@ -38,7 +38,7 @@ func NewInt64FromBytes(source []byte) (*Int64, error) {
 }
 
 func NewInt64FromBuffer(buf *bytes.Buffer) (*Int64, error) {
-	if buf.Len() < cltype.Int32ByteSize {
+	if buf.Len() < cltype.Int64ByteSize {
 		return nil, errors.New("buffer size is too small")
 	}
 	byteSlice := buf.Next(cltype.Int64ByteSize)

--- a/types/clvalue/int64.go
+++ b/types/clvalue/int64.go
@@ -3,6 +3,7 @@ package clvalue
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/make-software/casper-go-sdk/types/clvalue/cltype"
@@ -32,12 +33,15 @@ func NewCLInt64(val int64) *CLValue {
 	return &res
 }
 
-func NewInt64FromBytes(source []byte) *Int64 {
+func NewInt64FromBytes(source []byte) (*Int64, error) {
 	return NewInt64FromBuffer(bytes.NewBuffer(source))
 }
 
-func NewInt64FromBuffer(buf *bytes.Buffer) *Int64 {
+func NewInt64FromBuffer(buf *bytes.Buffer) (*Int64, error) {
+	if buf.Len() < cltype.Int32ByteSize {
+		return nil, errors.New("buffer size is too small")
+	}
 	byteSlice := buf.Next(cltype.Int64ByteSize)
 	val := Int64(int64(binary.LittleEndian.Uint64(byteSlice)))
-	return &val
+	return &val, nil
 }

--- a/types/clvalue/list.go
+++ b/types/clvalue/list.go
@@ -56,7 +56,11 @@ func NewListFromBytes(source []byte, clType *cltype.List) (*List, error) {
 }
 
 func NewListFromBuffer(buf *bytes.Buffer, clType *cltype.List) (*List, error) {
-	listSize := int(TrimByteSize(buf))
+	size, err := TrimByteSize(buf)
+	if err != nil {
+		return nil, err
+	}
+	listSize := int(size)
 	elements := make([]CLValue, 0)
 	for i := 0; i < listSize; i += 1 {
 		one, err := FromBufferByType(buf, clType.ElementsType)

--- a/types/clvalue/map.go
+++ b/types/clvalue/map.go
@@ -105,7 +105,10 @@ func NewMapFromBuffer(buffer *bytes.Buffer, mapType *cltype.Map) (*Map, error) {
 	var KeyVal CLValue
 	var ValVal CLValue
 	var err error
-	size := TrimByteSize(buffer)
+	size, err := TrimByteSize(buffer)
+	if err != nil {
+		return nil, err
+	}
 	for i := uint32(0); i < size; i++ {
 		if KeyVal, err = FromBufferByType(buffer, mapType.Key); err != nil {
 			return nil, err

--- a/types/clvalue/parser.go
+++ b/types/clvalue/parser.go
@@ -15,7 +15,10 @@ var (
 
 func FromBytes(source []byte) (CLValue, error) {
 	buffer := bytes.NewBuffer(source)
-	valueLength := TrimByteSize(buffer)
+	valueLength, err := TrimByteSize(buffer)
+	if err != nil {
+		return CLValue{}, err
+	}
 	clType, err := cltype.FromBytes(buffer.Bytes()[valueLength:])
 	if err != nil {
 		return CLValue{}, err
@@ -25,7 +28,10 @@ func FromBytes(source []byte) (CLValue, error) {
 }
 
 func FromBuffer(buffer *bytes.Buffer) (CLValue, error) {
-	valueLength := TrimByteSize(buffer)
+	valueLength, err := TrimByteSize(buffer)
+	if err != nil {
+		return CLValue{}, err
+	}
 	data := buffer.Next(int(valueLength))
 	clType, err := cltype.FromBuffer(buffer)
 	if err != nil {
@@ -55,20 +61,20 @@ func FromBufferByType(buf *bytes.Buffer, sourceType cltype.CLType) (result CLVal
 			result.Bool, err = NewBoolFromBuffer(buf)
 			return result, err
 		case cltype.TypeIDI32:
-			result.I32 = NewInt32FromBuffer(buf)
-			return result, nil
+			result.I32, err = NewInt32FromBuffer(buf)
+			return result, err
 		case cltype.TypeIDI64:
-			result.I64 = NewInt64FromBuffer(buf)
-			return result, nil
+			result.I64, err = NewInt64FromBuffer(buf)
+			return result, err
 		case cltype.TypeIDU8:
 			result.UI8, err = NewUInt8FromBuffer(buf)
 			return result, err
 		case cltype.TypeIDU32:
-			result.UI32 = NewUint32FromBuffer(buf)
-			return result, nil
+			result.UI32, err = NewUint32FromBuffer(buf)
+			return result, err
 		case cltype.TypeIDU64:
-			result.UI64 = NewUint64FromBuffer(buf)
-			return result, nil
+			result.UI64, err = NewUint64FromBuffer(buf)
+			return result, err
 		case cltype.TypeIDU128:
 			result.UI128, err = NewUint128FromBuffer(buf)
 			return result, err
@@ -79,8 +85,8 @@ func FromBufferByType(buf *bytes.Buffer, sourceType cltype.CLType) (result CLVal
 			result.UI512, err = NewUint512FromBuffer(buf)
 			return result, err
 		case cltype.TypeIDString:
-			result.StringVal = NewStringFromBuffer(buf)
-			return result, nil
+			result.StringVal, err = NewStringFromBuffer(buf)
+			return result, err
 		case cltype.TypeIDUnit:
 			result.Unit, err = NewUnitFromBuffer(buf)
 			return result, err

--- a/types/clvalue/result.go
+++ b/types/clvalue/result.go
@@ -28,8 +28,8 @@ func (v *Result) Value() CLValue {
 	return v.Inner
 }
 
-func NewCLResult(innerType cltype.CLType, value CLValue, isSuccess bool) CLValue {
-	resultType := cltype.NewResultType(innerType)
+func NewCLResult(innerOk, innerErr cltype.CLType, value CLValue, isSuccess bool) CLValue {
+	resultType := cltype.NewResultType(innerOk, innerErr)
 	return CLValue{
 		Type: resultType,
 		Result: &Result{
@@ -52,11 +52,19 @@ func NewResultFromBuffer(buf *bytes.Buffer, clType *cltype.Result) (*Result, err
 		return nil, err
 	}
 	val.IsSuccess = isSuccess == 1
-	inner, err := FromBufferByType(buf, clType.Inner)
-	if err != nil {
-		return nil, err
+	if val.IsSuccess {
+		inner, err := FromBufferByType(buf, clType.InnerOk)
+		if err != nil {
+			return nil, err
+		}
+		val.Inner = inner
+	} else {
+		inner, err := FromBufferByType(buf, clType.InnerErr)
+		if err != nil {
+			return nil, err
+		}
+		val.Inner = inner
 	}
-	val.Inner = inner
 
 	return &val, nil
 }

--- a/types/clvalue/string.go
+++ b/types/clvalue/string.go
@@ -25,13 +25,16 @@ func NewCLString(val string) *CLValue {
 	return &res
 }
 
-func NewStringFromBytes(src []byte) *String {
+func NewStringFromBytes(src []byte) (*String, error) {
 	buf := bytes.NewBuffer(src)
 	return NewStringFromBuffer(buf)
 }
 
-func NewStringFromBuffer(buffer *bytes.Buffer) *String {
-	size := TrimByteSize(buffer)
+func NewStringFromBuffer(buffer *bytes.Buffer) (*String, error) {
+	size, err := TrimByteSize(buffer)
+	if err != nil {
+		return nil, err
+	}
 	v := String(buffer.Next(int(size)))
-	return &v
+	return &v, nil
 }

--- a/types/clvalue/uint32.go
+++ b/types/clvalue/uint32.go
@@ -3,6 +3,7 @@ package clvalue
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/make-software/casper-go-sdk/types/clvalue/cltype"
@@ -24,7 +25,7 @@ func (v *UInt32) Value() uint32 {
 	return uint32(*v)
 }
 
-func NewUint32FromBytes(source []byte) *UInt32 {
+func NewUint32FromBytes(source []byte) (*UInt32, error) {
 	buf := bytes.NewBuffer(source)
 	return NewUint32FromBuffer(buf)
 }
@@ -37,14 +38,21 @@ func NewCLUInt32(val uint32) *CLValue {
 	return &res
 }
 
-func NewUint32FromBuffer(buffer *bytes.Buffer) *UInt32 {
+func NewUint32FromBuffer(buffer *bytes.Buffer) (*UInt32, error) {
+	if buffer.Len() < cltype.Int32ByteSize {
+		return nil, errors.New("buffer size is too small")
+	}
 	buf := buffer.Next(cltype.Int32ByteSize)
 	val := UInt32(binary.LittleEndian.Uint32(buf))
-	return &val
+	return &val, nil
 }
 
-func TrimByteSize(buf *bytes.Buffer) (size uint32) {
-	return NewUint32FromBuffer(buf).Value()
+func TrimByteSize(buf *bytes.Buffer) (size uint32, err error) {
+	buffer, err := NewUint32FromBuffer(buf)
+	if err != nil {
+		return 0, err
+	}
+	return buffer.Value(), nil
 }
 
 func SizeToBytes(val int) []byte {

--- a/types/clvalue/uint64.go
+++ b/types/clvalue/uint64.go
@@ -39,7 +39,7 @@ func NewUint64FromBytes(source []byte) (*UInt64, error) {
 }
 
 func NewUint64FromBuffer(buffer *bytes.Buffer) (*UInt64, error) {
-	if buffer.Len() < cltype.Int32ByteSize {
+	if buffer.Len() < cltype.Int64ByteSize {
 		return nil, errors.New("buffer size is too small")
 	}
 

--- a/types/clvalue/uint64.go
+++ b/types/clvalue/uint64.go
@@ -3,6 +3,7 @@ package clvalue
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/make-software/casper-go-sdk/types/clvalue/cltype"
@@ -32,13 +33,17 @@ func NewCLUInt64(val uint64) *CLValue {
 	return &res
 }
 
-func NewUint64FromBytes(source []byte) *UInt64 {
+func NewUint64FromBytes(source []byte) (*UInt64, error) {
 	buf := bytes.NewBuffer(source)
 	return NewUint64FromBuffer(buf)
 }
 
-func NewUint64FromBuffer(buffer *bytes.Buffer) *UInt64 {
+func NewUint64FromBuffer(buffer *bytes.Buffer) (*UInt64, error) {
+	if buffer.Len() < cltype.Int32ByteSize {
+		return nil, errors.New("buffer size is too small")
+	}
+
 	buf := buffer.Next(cltype.Int64ByteSize)
 	val := UInt64(binary.LittleEndian.Uint64(buf))
-	return &val
+	return &val, nil
 }

--- a/types/executable_deploy_item.go
+++ b/types/executable_deploy_item.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"math/big"
+	"strconv"
 
 	"github.com/make-software/casper-go-sdk/types/clvalue"
 	"github.com/make-software/casper-go-sdk/types/key"
@@ -130,15 +132,20 @@ type StoredVersionedContractByHash struct {
 	// Hash of the contract.
 	Hash key.ContractHash `json:"hash"`
 	// Entry point or method of the contract to call.
-	EntryPoint string  `json:"entry_point"`
-	Version    *string `json:"version,omitempty"`
-	Args       *Args   `json:"args"`
+	EntryPoint string       `json:"entry_point"`
+	Version    *json.Number `json:"version,omitempty"`
+	Args       *Args        `json:"args"`
 }
 
 func (m StoredVersionedContractByHash) Bytes() ([]byte, error) {
 	option := clvalue.Option{}
-	if m.Version != nil || *m.Version != "" {
-		option.Inner = clvalue.NewCLString(*m.Version)
+	if m.Version != nil || m.Version.String() != "" {
+		verVal, err := strconv.ParseUint(m.Version.String(), 10, 32)
+		if err != nil {
+			return nil, err
+		}
+
+		option.Inner = clvalue.NewCLUInt32(uint32(verVal))
 	}
 	argBytes, err := m.Args.Bytes()
 	if err != nil {
@@ -157,15 +164,20 @@ type StoredVersionedContractByName struct {
 	// Name of a named key in the caller account that stores the contract package hash.
 	Name string `json:"name"`
 	// Entry point or method of the contract to call.
-	EntryPoint string  `json:"entry_point"`
-	Version    *string `json:"version,omitempty"`
-	Args       *Args   `json:"args"`
+	EntryPoint string       `json:"entry_point"`
+	Version    *json.Number `json:"version,omitempty"`
+	Args       *Args        `json:"args"`
 }
 
 func (m StoredVersionedContractByName) Bytes() ([]byte, error) {
 	option := clvalue.Option{}
 	if m.Version != nil || *m.Version != "" {
-		option.Inner = clvalue.NewCLString(*m.Version)
+		verVal, err := strconv.ParseUint(m.Version.String(), 10, 32)
+		if err != nil {
+			return nil, err
+		}
+
+		option.Inner = clvalue.NewCLUInt32(uint32(verVal))
 	}
 	argBytes, err := m.Args.Bytes()
 	if err != nil {

--- a/types/time.go
+++ b/types/time.go
@@ -36,6 +36,9 @@ type Duration time.Duration
 
 func (d Duration) MarshalJSON() ([]byte, error) {
 	s := time.Duration(d).String()
+	if s == "24h0m0s" {
+		s = "1day"
+	}
 	if strings.HasSuffix(s, "h0m0s") {
 		s = strings.TrimSuffix(s, "0m0s")
 	}
@@ -51,7 +54,10 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &dataString); err != nil {
 		return err
 	}
-
+	dataString = strings.ReplaceAll(dataString, " ", "")
+	if dataString == "1day" {
+		dataString = "24h"
+	}
 	duration, err := time.ParseDuration(dataString)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Merge Release v1.1.3

### Summary

Big fixes.

- Fix validation for parsing Int64 size (https://github.com/make-software/casper-go-sdk/pull/25)
- Add handling the panic for parsing int values from the buffer (https://github.com/make-software/casper-go-sdk/pull/24)
- Fix a TTL format for the Deploy header (https://github.com/make-software/casper-go-sdk/pull/23)
- Fix contract version type (https://github.com/make-software/casper-go-sdk/pull/22)
- Fix CLResult parsing logic (https://github.com/make-software/casper-go-sdk/pull/21)


### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


