### PR TITLE
Fix public key parsing logic

### DIFF
--- a/tests/types/argument_test.go
+++ b/tests/types/argument_test.go
@@ -20,3 +20,15 @@ func Test_ParseResultArgument_shouldParseOk(t *testing.T) {
 	assert.True(t, val.Result.IsSuccess)
 	assert.Equal(t, "helloworld", val.Result.Value().String())
 }
+
+func Test_ParsePublicKeyArgument_shouldParseOk(t *testing.T) {
+	source := `{"cl_type":{"List":"PublicKey"},"bytes":"03000000010e31a03ea026a8e375653573e0120c8cb96699e6c9721ae1ea98f896e6576ac30193b3800386aefe11648150f6779158f2c7e1233c8e9b423338eb71b93ae6c5a90203c90c0ee375abc85da81a982507d1f8258a380af2058b63c37abdb9c7045940f4","parsed":["010e31a03ea026a8e375653573e0120c8cb96699e6c9721ae1ea98f896e6576ac3","0193b3800386aefe11648150f6779158f2c7e1233c8e9b423338eb71b93ae6c5a9", "0203c90c0ee375abc85da81a982507d1f8258a380af2058b63c37abdb9c7045940f4"]}`
+	var arg types.Argument
+	err := json.Unmarshal([]byte(source), &arg)
+	require.NoError(t, err)
+	val, err := arg.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "010e31a03ea026a8e375653573e0120c8cb96699e6c9721ae1ea98f896e6576ac3", val.List.Elements[0].PublicKey.String())
+	assert.Equal(t, "0193b3800386aefe11648150f6779158f2c7e1233c8e9b423338eb71b93ae6c5a9", val.List.Elements[1].PublicKey.String())
+	assert.Equal(t, "0203c90c0ee375abc85da81a982507d1f8258a380af2058b63c37abdb9c7045940f4", val.List.Elements[2].PublicKey.String())
+}

--- a/types/keypair/ed25519/public_key.go
+++ b/types/keypair/ed25519/public_key.go
@@ -4,10 +4,12 @@ import (
 	"crypto/ed25519"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"os"
 )
 
 const PemFramePublicKeyPrefixSize = 12
+const PublicKeySize = 32
 
 type PublicKey ed25519.PublicKey
 
@@ -19,8 +21,11 @@ func (v PublicKey) VerifySignature(message []byte, sig []byte) bool {
 	return ed25519.Verify(ed25519.PublicKey(v), message, sig)
 }
 
-func NewPublicKey(data []byte) PublicKey {
-	return PublicKey(data)
+func NewPublicKey(data []byte) (PublicKey, error) {
+	if len(data) != PublicKeySize {
+		return nil, fmt.Errorf("can't parse wrong size of public key: %d", len(data))
+	}
+	return PublicKey(data), nil
 }
 
 func ParsePublicKeyFile(path string) (PublicKey, error) {
@@ -36,5 +41,5 @@ func ParsePublicKeyFile(path string) (PublicKey, error) {
 	// Trim PEM prefix
 	data := block.Bytes[PemFramePublicKeyPrefixSize:]
 
-	return PublicKey(data), nil
+	return NewPublicKey(data)
 }

--- a/types/keypair/public_key.go
+++ b/types/keypair/public_key.go
@@ -159,9 +159,11 @@ func NewPublicKeyFromBuffer(buf *bytes.Buffer) (PublicKey, error) {
 	result.cryptoAlg = keyAlgorithm(alg)
 	switch result.cryptoAlg {
 	case ED25519:
-		result.key = ed25519.NewPublicKey(buf.Bytes())
+		if result.key, err = ed25519.NewPublicKey(buf.Next(ed25519.PublicKeySize)); err != nil {
+			return PublicKey{}, err
+		}
 	case SECP256K1:
-		if result.key, err = secp256k1.NewPublicKey(buf.Bytes()); err != nil {
+		if result.key, err = secp256k1.NewPublicKey(buf.Next(secp256k1.PublicKeySize)); err != nil {
 			return PublicKey{}, err
 		}
 	default:

--- a/types/keypair/secp256k1/public_key.go
+++ b/types/keypair/secp256k1/public_key.go
@@ -2,10 +2,13 @@ package secp256k1
 
 import (
 	"crypto/sha256"
+	"fmt"
 	"math/big"
 
 	"github.com/btcsuite/btcd/btcec"
 )
+
+const PublicKeySize = 33
 
 // used to reject malleable signatures
 // see:
@@ -54,6 +57,9 @@ func signatureFromBytes(sigStr []byte) *btcec.Signature {
 }
 
 func NewPublicKey(data []byte) (PublicKey, error) {
+	if len(data) != PublicKeySize {
+		return PublicKey{}, fmt.Errorf("can't parse wrong size of public key: %d", len(data))
+	}
 	key, err := btcec.ParsePubKey(data, btcec.S256())
 	if err != nil {
 		return PublicKey{}, err


### PR DESCRIPTION
# Fix public key parsing logic

### Fix issue:

`{"cl_type":{"List":"PublicKey"},"bytes":"02000000010e31a03ea026a8e375653573e0120c8cb96699e6c9721ae1ea98f896e6576ac30193b3800386aefe11648150f6779158f2c7e1233c8e9b423338eb71b93ae6c5a9","parsed":["010e31a03ea026a8e375653573e0120c8cb96699e6c9721ae1ea98f896e6576ac3","0193b3800386aefe11648150f6779158f2c7e1233c8e9b423338eb71b93ae6c5a9"]}`

Unable to parse to CLValue. With error - invalid public key algorithm

Also, found that ed25519.NewPublicKey has no size validation and just wraps incoming bytes to PublicKey type.


### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


