### PR TITLE
added additional constructor for ed priv key

### DIFF
--- a/types/keypair/ed25519/private_key.go
+++ b/types/keypair/ed25519/private_key.go
@@ -37,6 +37,10 @@ func NewPrivateKeyFromPEMFile(path string) (PrivateKey, error) {
 		return PrivateKey{}, errors.New("can't read file")
 	}
 
+	return NewPrivateKeyFromPEM(content)
+}
+
+func NewPrivateKeyFromPEM(content []byte) (PrivateKey, error) {
 	block, _ := pem.Decode(content)
 	// Trim PEM prefix
 	data := block.Bytes[PemFramePrivateKeyPrefixSize:]


### PR DESCRIPTION
This will make it possible to store the private key in storage (for example aws) as an array of bytes and not only in a file.
Also similar functional is already in your secp256k1 package, so another reason is to develop your packages identically.