### PR TITLE
Add copy to Scan method for public key

### DIFF
--- a/types/key/key.go
+++ b/types/key/key.go
@@ -210,7 +210,15 @@ func (k *Key) UnmarshalJSON(i []byte) error {
 }
 
 func (k *Key) Scan(value any) (err error) {
-	*k, err = NewKeyFromBuffer(bytes.NewBuffer(value.([]byte)))
+	data, ok := value.([]byte)
+	if !ok {
+		return errors.New("invalid scan value type")
+	}
+
+	dst := make([]byte, len(data))
+	copy(dst, data)
+
+	*k, err = NewKeyFromBuffer(bytes.NewBuffer(dst))
 	return err
 }
 

--- a/types/key/uref.go
+++ b/types/key/uref.go
@@ -121,7 +121,11 @@ func (v *URef) Scan(value interface{}) error {
 	if !ok {
 		return errors.New("invalid scan value type")
 	}
-	tmp, err := NewURefFromBytes(data)
+
+	dst := make([]byte, len(data))
+	copy(dst, data)
+
+	tmp, err := NewURefFromBytes(dst)
 	if err != nil {
 		return err
 	}

--- a/types/keypair/public_key.go
+++ b/types/keypair/public_key.go
@@ -100,7 +100,11 @@ func (v *PublicKey) Scan(value interface{}) error {
 	if !ok {
 		return errors.New("invalid scan value type")
 	}
-	tmp, err := NewPublicKeyFromBuffer(bytes.NewBuffer(data))
+
+	dst := make([]byte, len(data))
+	copy(dst, data)
+
+	tmp, err := NewPublicKeyFromBuffer(bytes.NewBuffer(dst))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Resolves: []byte values can be affected in the custom iteration using ScanStruct method

### Summary

Add copy to Scan method for public key

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


