### PR TITLE
Fix request ID data type

### DIFF
--- a/rpc/id_value.go
+++ b/rpc/id_value.go
@@ -1,0 +1,71 @@
+package rpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type IDValue struct {
+	intValue   int
+	strValue   string
+	isIntValue bool
+}
+
+func NewIDFromString(value string) *IDValue {
+	return &IDValue{
+		strValue:   value,
+		isIntValue: false,
+	}
+}
+
+func NewIDFromInt(value int) *IDValue {
+	return &IDValue{
+		intValue:   value,
+		isIntValue: true,
+	}
+}
+
+func (id *IDValue) String() string {
+	if id.isIntValue {
+		return strconv.Itoa(id.intValue)
+	}
+	return id.strValue
+}
+
+func (id *IDValue) Int() int {
+	if id.isIntValue {
+		return id.intValue
+	}
+	// Try to convert string to int
+	val, err := strconv.Atoi(id.strValue)
+	if err == nil {
+		return val
+	}
+	return 0
+}
+
+func (id *IDValue) MarshalJSON() ([]byte, error) {
+	if id.isIntValue {
+		return json.Marshal(id.intValue)
+	}
+	return json.Marshal(id.strValue)
+}
+
+func (id *IDValue) UnmarshalJSON(data []byte) error {
+	var intVal int
+	if err := json.Unmarshal(data, &intVal); err == nil {
+		id.intValue = intVal
+		id.isIntValue = true
+		return nil
+	}
+
+	var strVal string
+	if err := json.Unmarshal(data, &strVal); err == nil {
+		id.strValue = strVal
+		id.isIntValue = false
+		return nil
+	}
+
+	return fmt.Errorf("IDValue should be an int or string")
+}

--- a/rpc/request.go
+++ b/rpc/request.go
@@ -55,7 +55,7 @@ type RpcRequest struct {
 	// Version of the RPC protocol in use
 	Version string `json:"jsonrpc"`
 	// Id of the RPC request that can be correlated with the equivalent Id in the RPC response
-	ID     string      `json:"id,omitempty"`
+	ID     *IDValue    `json:"id,omitempty"`
 	Method Method      `json:"method"`
 	Params interface{} `json:"params"`
 }
@@ -63,7 +63,7 @@ type RpcRequest struct {
 func DefaultRpcRequest(method Method, params interface{}) RpcRequest {
 	return RpcRequest{
 		Version: ApiVersion,
-		ID:      "1",
+		ID:      NewIDFromString("1"),
 		Method:  method,
 		Params:  params,
 	}

--- a/rpc/response.go
+++ b/rpc/response.go
@@ -13,7 +13,7 @@ import (
 // contains the returned data as a JSON object. If an error occurs Error property contains a description of an error.
 type RpcResponse struct {
 	Version string          `json:"jsonrpc"`
-	Id      string          `json:"id,omitempty"`
+	Id      *IDValue        `json:"id,omitempty"`
 	Result  json.RawMessage `json:"result"`
 	Error   *RpcError       `json:"error,omitempty"`
 }

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -249,7 +249,7 @@ func (c *client) GetChainspec(ctx context.Context) (InfoGetChainspecResult, erro
 func (c *client) processRequest(ctx context.Context, method Method, params interface{}, result any) error {
 	request := DefaultRpcRequest(method, params)
 	if reqID := GetReqIdCtx(ctx); reqID != "0" {
-		request.ID = reqID
+		request.ID = NewIDFromString(reqID)
 	}
 	resp, err := c.handler.ProcessCall(ctx, request)
 	if err != nil {

--- a/rpc/speculative_client.go
+++ b/rpc/speculative_client.go
@@ -23,7 +23,7 @@ func (c SpeculativeClient) SpeculativeExec(ctx context.Context, deploy types.Dep
 		BlockIdentifier: identifier,
 	})
 	if reqID := GetReqIdCtx(ctx); reqID != "0" {
-		request.ID = reqID
+		request.ID = NewIDFromString(reqID)
 	}
 	resp, err := c.handler.ProcessCall(ctx, request)
 	if err != nil {


### PR DESCRIPTION
* Resolves: json: cannot unmarshal number into Go struct field RpcRequest.id of type string

### Summary

Fixed request ID data type to support both types: strings and numbers.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


