### PR TITLE
fix(types): Change NewValidator to be optional for UnbondingPurse (CMW-586)

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup GO environment
         run: |
           go mod vendor
-          go install -v github.com/incu6us/goimports-reviser/v3.5.6
+          go install -v github.com/incu6us/goimports-reviser/v3@v3.5.6
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
       - name: Format

--- a/types/unbonding_purse.go
+++ b/types/unbonding_purse.go
@@ -18,5 +18,5 @@ type UnbondingPurse struct {
 	// The original validator's public key.
 	ValidatorPublicKey keypair.PublicKey `json:"validator_public_key"`
 	// The re-delegated validator's public key.
-	NewValidator keypair.PublicKey `json:"new_validator"`
+	NewValidator *keypair.PublicKey `json:"new_validator"`
 }


### PR DESCRIPTION
This is an issue for use but I decided to create a quick fix PR because it is a one liner

The `NewValidator` field might be `nil` for `UnbondingPurse` is you can see here in the deploy transforms (WriteOnbonding) - [https://cspr.live/deploy/ef67b2f13c951ac9cc19db956d291c6564c56ce2c6288ab840af2559368b7fef](https://cspr.live/deploy/ef67b2f13c951ac9cc19db956d291c6564c56ce2c6288ab840af2559368b7fef)

Currently it blocks us on a casper cloud team side to sore withdrawals correctly, so I would as to include it in a nearest patch release please.


* Resolves: # <!-- related github issue -->

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


