### PR TITLE
feat: add WriteAccount transform parsing logic

### DIFF
--- a/types/transform.go
+++ b/types/transform.go
@@ -63,6 +63,23 @@ func (t *Transform) ParseAsWriteTransfer() (*WriteTransfer, error) {
 	return &jsonRes.WriteTransfer, nil
 }
 
+func (t *Transform) IsWriteAccount() bool {
+	return strings.Contains(string(*t), "WriteAccount")
+}
+
+func (t *Transform) ParseAsWriteAccount() (key.AccountHash, error) {
+	type RawWriteAccountTransform struct {
+		key.AccountHash `json:"WriteAccount"`
+	}
+
+	jsonRes := RawWriteAccountTransform{}
+	if err := json.Unmarshal(*t, &jsonRes); err != nil {
+		return key.AccountHash{}, err
+	}
+
+	return jsonRes.AccountHash, nil
+}
+
 func (t *Transform) IsWriteContract() bool {
 	return bytes.Equal(*t, []byte("\"WriteContract\""))
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

### Summary
We need to add parsing logic for `WriteAccount` transforms

Example: [this deploy](https://testnet.cspr.live/deploy/0bbdbd7fd190b32fac6fb244a450c57a81e937953ddb6ad14c1322b0f7b57e1d)

<img width="661" alt="Screenshot 2024-01-11 at 00 50 39" src="https://github.com/make-software/casper-go-sdk/assets/35244117/575f2bf7-f6e3-464b-a420-02e294dd74ce">


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


