### PR TITLE
Add switch_block_hash to info_get_reward RPC

### DIFF
--- a/rpc/response.go
+++ b/rpc/response.go
@@ -524,10 +524,11 @@ func (b QueryBalanceDetailsResult) GetRawJSON() json.RawMessage {
 }
 
 type InfoGetRewardResult struct {
-	APIVersion     string          `json:"api_version"`
-	DelegationRate float32         `json:"delegation_rate"`
-	EraID          uint64          `json:"era_id"`
-	RewardAmount   clvalue.UInt512 `json:"reward_amount"`
+	APIVersion      string          `json:"api_version"`
+	DelegationRate  float32         `json:"delegation_rate"`
+	EraID           uint64          `json:"era_id"`
+	RewardAmount    clvalue.UInt512 `json:"reward_amount"`
+	SwitchBlockHash key.Hash        `json:"switch_block_hash"`
 
 	rawJSON json.RawMessage
 }

--- a/tests/data/rpc_response/info_get_reward.json
+++ b/tests/data/rpc_response/info_get_reward.json
@@ -5,6 +5,7 @@
     "api_version": "2.0.0",
     "reward_amount": "62559062048560",
     "era_id": 13,
-    "delegation_rate": 1
+    "delegation_rate": 1,
+    "switch_block_hash": "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"
   }
 }

--- a/tests/rpc/rpc_client_test.go
+++ b/tests/rpc/rpc_client_test.go
@@ -608,6 +608,7 @@ func Test_DefaultClient_GetReward(t *testing.T) {
 			assert.NotEmpty(t, result.EraID)
 			assert.NotEmpty(t, result.RewardAmount)
 			assert.Equal(t, result.RewardAmount.Value().Int64(), int64(62559062048560))
+			assert.Equal(t, result.SwitchBlockHash.ToHex(), "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f")
 			assert.NotEmpty(t, result.GetRawJSON())
 		})
 	}


### PR DESCRIPTION
Added switch_block_hash to info_get_reward RPC


* Resolves: # <!-- related github issue -->

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


