### PR TITLE
Add panic and errors hansling

### DIFF
--- a/rpc/response.go
+++ b/rpc/response.go
@@ -183,15 +183,16 @@ func (v *InfoGetDeployResult) UnmarshalJSON(data []byte) error {
 
 	if !strings.HasPrefix(version.ApiVersion, "2") {
 		var v1Compatible infoGetDeployResultV1Compatible
-		if err := json.Unmarshal(data, &v1Compatible); err == nil {
-			*v = InfoGetDeployResult{
-				ApiVersion:       v1Compatible.ApiVersion,
-				Deploy:           v1Compatible.Deploy,
-				ExecutionResults: types.DeployExecutionInfoFromV1(v1Compatible.ExecutionResults, v1Compatible.BlockHeight),
-				rawJSON:          data,
-			}
-			return nil
+		if err := json.Unmarshal(data, &v1Compatible); err != nil {
+			return err
 		}
+		*v = InfoGetDeployResult{
+			ApiVersion:       v1Compatible.ApiVersion,
+			Deploy:           v1Compatible.Deploy,
+			ExecutionResults: types.DeployExecutionInfoFromV1(v1Compatible.ExecutionResults, v1Compatible.BlockHeight),
+			rawJSON:          data,
+		}
+		return nil
 	}
 
 	var resp struct {

--- a/types/execution_result.go
+++ b/types/execution_result.go
@@ -152,14 +152,16 @@ func NewExecutionResultFromV1(v1 ExecutionResultV1) ExecutionResult {
 				Kind: TransformKind(transform.Transform),
 			})
 		}
+
+		return ExecutionResult{
+			ErrorMessage:            &v1.Failure.ErrorMessage,
+			Consumed:                v1.Failure.Cost,
+			Effects:                 transforms,
+			originExecutionResultV1: &v1,
+		}
 	}
 
-	return ExecutionResult{
-		ErrorMessage:            &v1.Failure.ErrorMessage,
-		Consumed:                v1.Failure.Cost,
-		Effects:                 transforms,
-		originExecutionResultV1: &v1,
-	}
+	return ExecutionResult{}
 }
 
 // ExecutionResultV2 represents the result of executing a single deploy for V2 version

--- a/types/transaction_scheduling.go
+++ b/types/transaction_scheduling.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/make-software/casper-go-sdk/v2/types/clvalue"
@@ -73,14 +74,17 @@ func (t *TransactionScheduling) UnmarshalJSON(data []byte) error {
 	}
 
 	var key string
-	if err := json.Unmarshal(data, &key); err == nil && key == "Standard" {
+	if err := json.Unmarshal(data, &key); err != nil {
+		return err
+	}
+	if key == "Standard" {
 		*t = TransactionScheduling{
 			Standard: &struct{}{},
 		}
 		return nil
 	}
 
-	return nil
+	return fmt.Errorf("unknown transaction scheduling type: %s", key)
 }
 
 func (t TransactionScheduling) MarshalJSON() ([]byte, error) {

--- a/types/transaction_target.go
+++ b/types/transaction_target.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/make-software/casper-go-sdk/v2/types/clvalue"
 	"github.com/make-software/casper-go-sdk/v2/types/key"
@@ -104,14 +105,17 @@ func (t *TransactionTarget) UnmarshalJSON(data []byte) error {
 	}
 
 	var key string
-	if err := json.Unmarshal(data, &key); err == nil && key == "Native" {
+	if err := json.Unmarshal(data, &key); err != nil {
+		return err
+	}
+	if key == "Native" {
 		*t = TransactionTarget{
 			Native: &struct{}{},
 		}
 		return nil
 	}
 
-	return nil
+	return fmt.Errorf("unknown transaction target type: %s", key)
 }
 
 func (t TransactionTarget) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
There are fixes for handling panics and some unmarshaling errors. 
Also, we have some muted errors in the new types of constructors that could lead to implicit behaviour and problems with debugging, I'm good with it where we have to keep simple interfaces. But let's handle errors where we can return them without changing functions' signatures.


