### PR TITLE
Fixed parsing write account

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,4 +183,4 @@ Should you have any questions, issues, or suggestions, please don't hesitate to 
 
 Remember, the power of blockchain networks is in their communities. Every question you ask, issue you open, or contribution you make, helps to improve the Casper Go SDK and benefits the entire Casper ecosystem.
 
-Thank you for your interest in our project, we look forward to building the future of the Casper Network together!
+Thank you for your interest in our project, and we look forward to building the future of the Casper Network together!

--- a/README.md
+++ b/README.md
@@ -183,4 +183,4 @@ Should you have any questions, issues, or suggestions, please don't hesitate to 
 
 Remember, the power of blockchain networks is in their communities. Every question you ask, issue you open, or contribution you make, helps to improve the Casper Go SDK and benefits the entire Casper ecosystem.
 
-Thank you for your interest in our project, and we look forward to building the future of the Casper Network together!
+Thank you for your interest in our project, we look forward to building the future of the Casper Network together!

--- a/tests/data/transform/write_account_v1.json
+++ b/tests/data/transform/write_account_v1.json
@@ -1,0 +1,6 @@
+{
+  "key": "account-hash-ecafdf1431e400b5e5aca05b01f37aef913be55f24ed4aaf16c9668346d9d683",
+  "transform": {
+    "WriteAccount": "account-hash-ecafdf1431e400b5e5aca05b01f37aef913be55f24ed4aaf16c9668346d9d683"
+  }
+}

--- a/tests/data/transform/write_account_v2.json
+++ b/tests/data/transform/write_account_v2.json
@@ -1,0 +1,22 @@
+{
+  "key": "account-hash-44ec1f3f9114f49593d6dd70d38432947288f0c9f71f673555db1f5867aecf73",
+  "kind": {
+    "Write": {
+      "Account": {
+        "account_hash": "account-hash-44ec1f3f9114f49593d6dd70d38432947288f0c9f71f673555db1f5867aecf73",
+        "named_keys": [],
+        "main_purse": "uref-b7f9d1fe77817e0fd9bc5bd67d02ccc402ffcaeb9978015e118a39cd5dca463c-007",
+        "associated_keys": [
+          {
+            "account_hash": "account-hash-44ec1f3f9114f49593d6dd70d38432947288f0c9f71f673555db1f5867aecf73",
+            "weight": 1
+          }
+        ],
+        "action_thresholds": {
+          "deployment": 1,
+          "key_management": 1
+        }
+      }
+    }
+  }
+}

--- a/tests/types/transform_test.go
+++ b/tests/types/transform_test.go
@@ -228,11 +228,11 @@ func Test_Transform_MessageTopic(t *testing.T) {
 }
 
 func Test_Transform_WriteDeployInfo(t *testing.T) {
-	fixute, err := os.ReadFile("../data/transform/WriteDeployInfo.json")
+	fixture, err := os.ReadFile("../data/transform/WriteDeployInfo.json")
 	require.NoError(t, err)
 	var transformKey types.TransformKey
 
-	err = json.Unmarshal(fixute, &transformKey)
+	err = json.Unmarshal(fixture, &transformKey)
 	require.NoError(t, err)
 
 	val, err := transformKey.Transform.ParseAsWriteDeployInfo()
@@ -240,4 +240,32 @@ func Test_Transform_WriteDeployInfo(t *testing.T) {
 
 	assert.True(t, transformKey.Transform.IsWriteDeployInfo())
 	assert.EqualValues(t, 1, len(val.Transfers))
+}
+
+func Test_Transform_WriteAccountV1(t *testing.T) {
+	fixture, err := os.ReadFile("../data/transform/write_account_v1.json")
+	require.NoError(t, err)
+	var transform types.TransformKey
+
+	err = json.Unmarshal(fixture, &transform)
+	require.NoError(t, err)
+
+	writeAccount, err := transform.Transform.ParseAsWriteAccount()
+	require.NoError(t, err)
+	require.NotEmpty(t, writeAccount.Hash)
+	assert.True(t, transform.Transform.IsWriteAccount())
+}
+
+func Test_Transform_WriteAccountV2(t *testing.T) {
+	fixture, err := os.ReadFile("../data/transform/write_account_v2.json")
+	require.NoError(t, err)
+	var transform types.Transform
+
+	err = json.Unmarshal(fixture, &transform)
+	require.NoError(t, err)
+
+	writeAccount, err := transform.Kind.ParseAsWriteAccount()
+	require.NoError(t, err)
+	require.NotEmpty(t, writeAccount.Hash)
+	assert.True(t, transform.Kind.IsWriteAccount())
 }


### PR DESCRIPTION
Example of the write account on devnet 2.0
[https://devnet.cspr.live/transaction/a3e003749a73223d5a5413518efbf6b27081fe76c999a13f7173e18293d0a5b2](https://devnet.cspr.live/transaction/a3e003749a73223d5a5413518efbf6b27081fe76c999a13f7173e18293d0a5b2)

on mainnet 1.5
[https://cspr.live/deploy/26f687bc00d9fa5e7652c014577cb45131ac1ffcce89be0b37bc6863093659c3](https://cspr.live/deploy/26f687bc00d9fa5e7652c014577cb45131ac1ffcce89be0b37bc6863093659c3)


### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


