### PR TITLE
Added "System" block creator support to InfoGetStatus RPC

### DIFF
--- a/tests/data/rpc_response/get_status_system_creator.json
+++ b/tests/data/rpc_response/get_status_system_creator.json
@@ -1,0 +1,43 @@
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": {
+    "api_version": "2.0.0",
+    "protocol_version": "5.4.3",
+    "peers": [],
+    "build_version": "2.0.0",
+    "chainspec_name": "dev-net",
+    "starting_state_root_hash": "b275db1f79912c7b2507a8e48f5ef15e6ae3236bed542c7710ce15321622d1cb",
+    "last_added_block_info": {
+      "hash": "e8637cdc918e901c6e10a050cc7d3be949b892dc8842580088f5aa592a342d39",
+      "timestamp": "2024-05-15T07:52:31.214Z",
+      "era_id": 386,
+      "height": 170022,
+      "state_root_hash": "18502c7912b294d65cadbaaf6a60b9d04b376224d540e31fca184606b16c706c",
+      "creator": "00"
+    },
+    "our_public_signing_key": "01032146b0b9de01e26aaec7b0d1769920de94681dbd432c3530bfe591752ded6c",
+    "round_length": "16s 384ms",
+    "next_upgrade": null,
+    "uptime": "1month 1day 17h 40m 43s",
+    "reactor_state": "Validate",
+    "last_progress": "2024-04-13T03:38:19.626Z",
+    "available_block_range": {
+      "low": 0,
+      "high": 170022
+    },
+    "block_sync": {
+      "historical": {
+        "block_hash": "16ddf28e2b3d2e17f4cef36f8b58827eca917af225d139b0c77df3b4a67dc55e",
+        "block_height": 40,
+        "acquisition_state": "have strict finality(40) for: block hash 16dd..c55e"
+      },
+      "forward": {
+        "block_hash": "59907b1e32a9158169c4d89d9ce5ac9164fc31240bfcfb0969227ece06d74983",
+        "block_height": 6701,
+        "acquisition_state": "have block body(6701) for: block hash 5990..4983"
+      }
+    },
+    "latest_switch_block_hash": "099cc3232b04ebb556c73328597c0b8c518fa4565c7d1f7981bc251414ce8c2f"
+  }
+}

--- a/tests/rpc/rpc_client_test.go
+++ b/tests/rpc/rpc_client_test.go
@@ -962,6 +962,10 @@ func Test_DefaultClient_GetStatus(t *testing.T) {
 	result, err := client.GetStatus(context.Background())
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.ChainSpecName)
+	assert.False(t, result.LastAddedBlockInfo.Creator.IsSystem())
+	creator, err := result.LastAddedBlockInfo.Creator.PublicKey()
+	require.NoError(t, err)
+	assert.Equal(t, "0140afe8f752e5ff100e0189c080bc207e8805b3e5e82f792ec608de2f11f39f6c", creator.ToHex())
 	assert.NotEmpty(t, result.LatestSwitchBlockHash)
 	assert.NotNil(t, result.BlockSync.Forward)
 	assert.NotEmpty(t, result.BlockSync.Forward.BlockHash)
@@ -971,6 +975,23 @@ func Test_DefaultClient_GetStatus(t *testing.T) {
 	assert.NotEmpty(t, result.BlockSync.Historical.BlockHash)
 	assert.NotEmpty(t, result.BlockSync.Historical.AcquisitionState)
 	assert.NotNil(t, result.BlockSync.Historical.BlockHeight)
+}
+
+func Test_InfoGetStatusResult_SystemCreator(t *testing.T) {
+	fixture, err := os.ReadFile("../data/rpc_response/get_status_system_creator.json")
+	require.NoError(t, err)
+
+	var response rpc.RpcResponse
+	err = json.Unmarshal(fixture, &response)
+	require.NoError(t, err)
+
+	var result rpc.InfoGetStatusResult
+	err = json.Unmarshal(response.Result, &result)
+	require.NoError(t, err)
+
+	assert.True(t, result.LastAddedBlockInfo.Creator.IsSystem())
+	assert.Equal(t, uint64(386), result.LastAddedBlockInfo.EraID)
+	assert.Equal(t, uint32(170022), result.LastAddedBlockInfo.Height)
 }
 
 func Test_DefaultClient_GetPeers(t *testing.T) {

--- a/types/minimal_block_info.go
+++ b/types/minimal_block_info.go
@@ -4,14 +4,13 @@ import (
 	"time"
 
 	"github.com/make-software/casper-go-sdk/v2/types/key"
-	"github.com/make-software/casper-go-sdk/v2/types/keypair"
 )
 
 type MinimalBlockInfo struct {
-	Creator       keypair.PublicKey `json:"creator"`
-	EraID         uint64            `json:"era_id"`
-	Hash          key.Hash          `json:"hash"`
-	Height        uint32            `json:"height"`
-	StateRootHash key.Hash          `json:"state_root_hash"`
-	Timestamp     time.Time         `json:"timestamp"`
+	Creator       Proposer  `json:"creator"`
+	EraID         uint64    `json:"era_id"`
+	Hash          key.Hash  `json:"hash"`
+	Height        uint32    `json:"height"`
+	StateRootHash key.Hash  `json:"state_root_hash"`
+	Timestamp     time.Time `json:"timestamp"`
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

### Summary

Fixes `info_get_status` unmarshalling when `last_added_block_info.creator` is the system proposer value `"00"`.

`MinimalBlockInfo.Creator` now uses `types.Proposer` instead of `keypair.PublicKey`, matching the existing block proposer model and allowing both regular public keys and the system proposer sentinel to decode through the existing `NewProposer` path.

Adds a regression test that unmarshals an `InfoGetStatusResult` fixture with `creator: "00"`.

### TODO

- [ ] Confirm related GitHub issue number

### Checklist

- [x] Code is properly formatted
- [ ] All commits are signed
- [x] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required